### PR TITLE
sm8350-common: overlay: Show AOSP volume panel on the left side

### DIFF
--- a/overlay-xtended/XtendedSettingsProviderResCommon/res/values/defaults.xml
+++ b/overlay-xtended/XtendedSettingsProviderResCommon/res/values/defaults.xml
@@ -5,4 +5,7 @@
 -->
 <resources>
 
+     <!-- Default for Settings.Secure.VOLUME_PANEL_ON_LEFT -->
+     <bool name="def_volume_panel_on_left">true</bool>
+
 </resources>


### PR DESCRIPTION
 - cuz this is where our volume buttons are